### PR TITLE
Updated target to `netstandard2.0`

### DIFF
--- a/src/NetMQ.Security/NetMQ.Security.csproj
+++ b/src/NetMQ.Security/NetMQ.Security.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>NetMQ.Security</AssemblyName>
     <AssemblyOriginatorKeyFile>../../NetMQ.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/NetMQ.Security/V0_1/HandshakeLayer.cs
+++ b/src/NetMQ.Security/V0_1/HandshakeLayer.cs
@@ -107,8 +107,7 @@ namespace NetMQ.Security.V0_1
                 CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA
             };
 
-#warning This method is not available in .NETStandard 1.6 - planned for 2.0; using X509Chain for now as it has the same functionality in NetFx, where X509Certificate2.Verify() calls the same internal method as X509Chain().Build(c)
-            VerifyCertificate = c => new X509Chain().Build(c); //c.Verify();
+            VerifyCertificate = c => c.Verify();
         }
 
         public SecurityParameters SecurityParameters { get; }

--- a/tests/NetMQ.Security.Tests/NetMQ.Security.Tests.csproj
+++ b/tests/NetMQ.Security.Tests/NetMQ.Security.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <AssemblyName>NetMQ.Security.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../NetMQ.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
This change updates the target of the library to `netstandard2.0` [as recommended by Microsoft](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/9.0/netstandard-warning) so it can be consumed from newer .NET code.